### PR TITLE
Improve 'wp super-admin' command description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 wp-cli/super-admin-command
 ==========================
 
-Manage super admins on WordPress multisite.
+Lists, adds, or removes super admin users on a multisite install.
 
 [![Build Status](https://travis-ci.org/wp-cli/super-admin-command.svg?branch=master)](https://travis-ci.org/wp-cli/super-admin-command)
 

--- a/src/Super_Admin_Command.php
+++ b/src/Super_Admin_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Manage super admins on WordPress multisite.
+ * Lists, adds, or removes super admin users on a multisite install.
  *
  * ## EXAMPLES
  *


### PR DESCRIPTION
Related: [/wp-cli/issues/4302](https://github.com/wp-cli/wp-cli/issues/4302)

Chnaged 'wp super-admin command description in:
https://github.com/wp-cli/super-admin-command/blob/master/src/Super_Admin_Command.php
https://github.com/wp-cli/super-admin-command/blob/master/README.md

Current description: Manage super admins on WordPress multisite.

New description:
Lists, adds, or removes super admin users on a multisite install.