### PR TITLE
Convert super-admin subcommand help summaries to use third-person singular verbs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 wp-cli/super-admin-command
 ==========================
 
-Lists, adds, or removes super admin users on a multisite install.
+Lists, adds, or removes super admin users on a multisite installation.
 
 [![Build Status](https://travis-ci.org/wp-cli/super-admin-command.svg?branch=master)](https://travis-ci.org/wp-cli/super-admin-command)
 
@@ -11,9 +11,34 @@ Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contr
 
 This package implements the following commands:
 
+### wp super-admin
+
+Lists, adds, or removes super admin users on a multisite installation.
+
+~~~
+wp super-admin
+~~~
+
+**EXAMPLES**
+
+    # List user with super-admin capabilities
+    $ wp super-admin list
+    supervisor
+    administrator
+
+    # Grant super-admin privileges to the user.
+    $ wp super-admin add superadmin2
+    Success: Granted super-admin capabilities.
+
+    # Revoke super-admin privileges to the user.
+    $ wp super-admin remove superadmin2
+    Success: Revoked super-admin capabilities.
+
+
+
 ### wp super-admin add
 
-Grant super admin privileges to one or more users.
+Grants super admin privileges to one or more users.
 
 ~~~
 wp super-admin add <user>...
@@ -33,7 +58,7 @@ wp super-admin add <user>...
 
 ### wp super-admin list
 
-List users with super admin capabilities.
+Lists users with super admin capabilities.
 
 ~~~
 wp super-admin list [--format=<format>]
@@ -65,7 +90,7 @@ wp super-admin list [--format=<format>]
 
 ### wp super-admin remove
 
-Remove super admin privileges from one or more users.
+Removes super admin privileges from one or more users.
 
 ~~~
 wp super-admin remove <user>...

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-cli/super-admin-command",
-    "description": "Lists, adds, or removes super admin users on a multisite install.",
+    "description": "Lists, adds, or removes super admin users on a multisite installation.",
     "type": "wp-cli-package",
     "homepage": "https://github.com/wp-cli/super-admin-command",
     "support": {
@@ -34,6 +34,7 @@
             "dev-master": "1.x-dev"
         },
         "commands": [
+            "super-admin",
             "super-admin add",
             "super-admin list",
             "super-admin remove"

--- a/src/Super_Admin_Command.php
+++ b/src/Super_Admin_Command.php
@@ -31,7 +31,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * List users with super admin capabilities.
+	 * Lists users with super admin capabilities.
 	 *
 	 * ## OPTIONS
 	 *
@@ -80,7 +80,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Grant super admin privileges to one or more users.
+	 * Grants super admin privileges to one or more users.
 	 *
 	 * ## OPTIONS
 	 *
@@ -136,7 +136,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Remove super admin privileges from one or more users.
+	 * Removes super admin privileges from one or more users.
 	 *
 	 * ## OPTIONS
 	 *

--- a/src/Super_Admin_Command.php
+++ b/src/Super_Admin_Command.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Lists, adds, or removes super admin users on a multisite install.
+ * Lists, adds, or removes super admin users on a multisite installation.
  *
  * ## EXAMPLES
  *


### PR DESCRIPTION
Per wp-cli/wp-cli#4542, this PR converts help docs for super-admin subcommands to use third-person singular verbs.