### PR TITLE
Trigger core actions when granting or revoking super admin permissions

### DIFF
--- a/features/super-admin.feature
+++ b/features/super-admin.feature
@@ -254,16 +254,7 @@ Feature: Manage super admins associated with a multisite instance
       """
 
     When I run `wp user create superadmin superadmin@example.com`
-    Then STDOUT should contain:
-      """
-      grant_super_admin hook was fired.
-      """
-    And STDOUT should contain:
-      """
-      granted_super_admin hook was fired.
-      """
-
-    When I run `wp super-admin add superadmin`
+    And I run `wp super-admin add superadmin`
     Then STDOUT should contain:
       """
       grant_super_admin hook was fired.
@@ -294,7 +285,7 @@ Feature: Manage super admins associated with a multisite instance
       """
 
     When I try `wp super-admin add noadmin`
-    Then STDOUT should contain:
+    Then STDOUT should not contain:
       """
       grant_super_admin hook was fired.
       """
@@ -314,7 +305,7 @@ Feature: Manage super admins associated with a multisite instance
       """
 
     When I try `wp super-admin remove noadmin`
-    Then STDOUT should contain:
+    Then STDOUT should not contain:
       """
       revoke_super_admin hook was fired.
       """

--- a/features/super-admin.feature
+++ b/features/super-admin.feature
@@ -234,7 +234,7 @@ Feature: Manage super admins associated with a multisite instance
     When I run `wp super-admin list`
     Then STDERR should be empty
 
-  Scenario: Add, list, and remove super admins.
+  Scenario: Hooks should be firing as expected
     Given a WP multisite installation
     And a wp-content/mu-plugins/test-hooks.php file:
       """

--- a/features/super-admin.feature
+++ b/features/super-admin.feature
@@ -2,6 +2,7 @@ Feature: Manage super admins associated with a multisite instance
 
   Scenario: Add, list, and remove super admins.
     Given a WP multisite installation
+
     When I run `wp user create superadmin superadmin@example.com`
     And I run `wp super-admin list`
     Then STDOUT should be:
@@ -232,3 +233,112 @@ Feature: Manage super admins associated with a multisite instance
 
     When I run `wp super-admin list`
     Then STDERR should be empty
+
+  Scenario: Add, list, and remove super admins.
+    Given a WP multisite installation
+    And a wp-content/mu-plugins/test-hooks.php file:
+      """
+      <?php
+      add_action( 'grant_super_admin', static function () {
+        WP_CLI::log( 'grant_super_admin hook was fired.' );
+      });
+      add_action( 'granted_super_admin', static function () {
+        WP_CLI::log( 'granted_super_admin hook was fired.' );
+      });
+      add_action( 'revoke_super_admin', static function () {
+        WP_CLI::log( 'revoke_super_admin hook was fired.' );
+      });
+      add_action( 'revoked_super_admin', static function () {
+        WP_CLI::log( 'revoked_super_admin hook was fired.' );
+      });
+      """
+
+    When I run `wp user create superadmin superadmin@example.com`
+    Then STDOUT should contain:
+      """
+      grant_super_admin hook was fired.
+      """
+    And STDOUT should contain:
+      """
+      granted_super_admin hook was fired.
+      """
+
+    When I run `wp super-admin add superadmin`
+    Then STDOUT should contain:
+      """
+      grant_super_admin hook was fired.
+      """
+    And STDOUT should contain:
+      """
+      granted_super_admin hook was fired.
+      """
+
+    When I try `wp super-admin add superadmin`
+    Then STDOUT should contain:
+      """
+      grant_super_admin hook was fired.
+      """
+    And STDOUT should not contain:
+      """
+      granted_super_admin hook was fired.
+      """
+
+    When I run `wp super-admin remove admin`
+    Then STDOUT should contain:
+      """
+      revoke_super_admin hook was fired.
+      """
+    And STDOUT should contain:
+      """
+      revoked_super_admin hook was fired.
+      """
+
+    When I try `wp super-admin add noadmin`
+    Then STDOUT should contain:
+      """
+      grant_super_admin hook was fired.
+      """
+    And STDOUT should not contain:
+      """
+      granted_super_admin hook was fired.
+      """
+
+    When I try `wp super-admin add admin noadmin`
+    Then STDOUT should contain:
+      """
+      grant_super_admin hook was fired.
+      """
+    And STDOUT should not contain:
+      """
+      granted_super_admin hook was fired.
+      """
+
+    When I try `wp super-admin remove noadmin`
+    Then STDOUT should contain:
+      """
+      revoke_super_admin hook was fired.
+      """
+    And STDOUT should not contain:
+      """
+      revoked_super_admin hook was fired.
+      """
+
+    When I try `wp super-admin remove admin admin@example.com noadmin superadmin`
+    Then STDOUT should contain:
+      """
+      revoke_super_admin hook was fired.
+      """
+    And STDOUT should contain:
+      """
+      revoked_super_admin hook was fired.
+      """
+
+    When I try `wp super-admin remove superadmin`
+    Then STDOUT should contain:
+      """
+      revoke_super_admin hook was fired.
+      """
+    And STDOUT should not contain:
+      """
+      revoked_super_admin hook was fired.
+      """

--- a/src/Super_Admin_Command.php
+++ b/src/Super_Admin_Command.php
@@ -160,11 +160,6 @@ class Super_Admin_Command extends WP_CLI_Command {
 	 *     Success: Revoked super-admin capabilities.
 	 */
 	public function remove( $args, $_ ) {
-		$super_admins = self::get_admins();
-		if ( ! $super_admins ) {
-			WP_CLI::error( 'No super admins to revoke super-admin privileges from.' );
-		}
-
 		$users             = $this->fetcher->get_many( $args );
 		$user_logins       = $users ? array_values( array_unique( wp_list_pluck( $users, 'user_login' ) ) ) : [];
 		$user_logins_count = count( $user_logins );
@@ -174,6 +169,11 @@ class Super_Admin_Command extends WP_CLI_Command {
 			$user_ids[ $user->user_login ] = $user->ID;
 
 			do_action( 'revoke_super_admin', (int) $user->ID ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		}
+
+		$super_admins = self::get_admins();
+		if ( ! $super_admins ) {
+			WP_CLI::error( 'No super admins to revoke super-admin privileges from.' );
 		}
 
 		if ( $user_logins_count < count( $args ) ) {

--- a/src/Super_Admin_Command.php
+++ b/src/Super_Admin_Command.php
@@ -108,7 +108,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 
 		$new_super_admins = [];
 		foreach ( $users as $user ) {
-			do_action( 'grant_super_admin', (int) $user->ID );
+			do_action( 'grant_super_admin', (int) $user->ID ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 
 			if ( in_array( $user->user_login, $super_admins, true ) ) {
 				WP_CLI::warning( "User '{$user->user_login}' already has super-admin capabilities." );
@@ -142,7 +142,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 		}
 
 		foreach ( $new_super_admins as $user_id ) {
-			do_action( 'granted_super_admin', (int) $user_id );
+			do_action( 'granted_super_admin', (int) $user_id ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		}
 	}
 
@@ -173,7 +173,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 		foreach ( $users as $user ) {
 			$user_ids[ $user->user_login ] = $user->ID;
 
-			do_action( 'revoke_super_admin', (int) $user->ID );
+			do_action( 'revoke_super_admin', (int) $user->ID ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		}
 
 		if ( $user_logins_count < count( $args ) ) {
@@ -199,7 +199,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 		}
 
 		// Ensure we always have an ID for all logins.
-		foreach( $user_logins as $user_login ) {
+		foreach ( $user_logins as $user_login ) {
 			if ( ! array_key_exists( $user_login, $user_ids ) ) {
 				$user                    = get_user_by( 'login', $user_login );
 				$user_ids[ $user_login ] = $user->ID;
@@ -227,7 +227,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 
 		$removed_logins = array_intersect( $user_logins, $super_admins );
 		foreach ( $removed_logins as $user_login ) {
-			do_action( 'revoked_super_admin', (int) $user_ids[ $user_login ] );
+			do_action( 'revoked_super_admin', (int) $user_ids[ $user_login ] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		}
 	}
 


### PR DESCRIPTION
When granting or revoking super admin permissions in WordPress, hooks are triggered which are missing in this implementation. By calling `grant_super_admin()` or `revoke_super_admin()` respectively, the following actions are triggered:

* `grant_super_admin` (before changes, _always_ executed)
* `granted_super_admin` (after changes, executed only on success)
* `revoke_super_admin` (before changes, _always_ executed)
* `revoked_super_admin` (after changes, executed only on success)

This PR adds the hooks so that plugin functionality integrating with these hooks still works correctly.