### PR TITLE
Implement CS checking based on the `WP_CLI_CS` ruleset

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -6,6 +6,8 @@
 .travis.yml
 behat.yml
 circle.yml
+phpcs.xml.dist
+phpunit.xml.dist
 bin/
 features/
 utils/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 .DS_Store
+.phpcs.xml
+phpunit.xml
+phpcs.xml
 wp-cli.local.yml
 node_modules/
 vendor/

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "wp-cli/entity-command": "^1.3 || ^2",
-        "wp-cli/wp-cli-tests": "^2.0.7"
+        "wp-cli/wp-cli-tests": "^2.1"
     },
     "config": {
         "process-timeout": 7200,

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -50,5 +50,8 @@
 			</property>
 		</properties>
 	</rule>
-
+	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
+		<exclude-pattern>*/src/Super_Admin_Command\.php$</exclude-pattern>
+	</rule>
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,54 @@
+<?xml version="1.0"?>
+<ruleset name="WP-CLI-super-admin">
+	<description>Custom ruleset for WP-CLI super-admin-command</description>
+
+	<!--
+	#############################################################################
+	COMMAND LINE ARGUMENTS
+	For help understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml
+	For help using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage
+	#############################################################################
+	-->
+
+	<!-- What to scan. -->
+	<file>.</file>
+
+	<!-- Show progress. -->
+	<arg value="p"/>
+
+	<!-- Strip the filepaths down to the relevant bit. -->
+	<arg name="basepath" value="./"/>
+
+	<!-- Check up to 8 files simultaneously. -->
+	<arg name="parallel" value="8"/>
+
+	<!--
+	#############################################################################
+	USE THE WP_CLI_CS RULESET
+	#############################################################################
+	-->
+
+	<rule ref="WP_CLI_CS"/>
+
+	<!--
+	#############################################################################
+	PROJECT SPECIFIC CONFIGURATION FOR SNIFFS
+	#############################################################################
+	-->
+
+	<!-- For help understanding the `testVersion` configuration setting:
+		 https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
+	<config name="testVersion" value="5.4-"/>
+
+	<!-- Verify that everything in the global namespace is either namespaced or prefixed.
+		 See: https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#naming-conventions-prefix-everything-in-the-global-namespace -->
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element value="WP_CLI\SuperAdmin"/><!-- Namespaces. -->
+				<element value="wpcli_super_admin"/><!-- Global variables and such. -->
+			</property>
+		</properties>
+	</rule>
+
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -50,6 +50,7 @@
 			</property>
 		</properties>
 	</rule>
+
 	<!-- Exclude existing classes from the prefix rule as it would break BC to prefix them now. -->
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound">
 		<exclude-pattern>*/src/Super_Admin_Command\.php$</exclude-pattern>

--- a/src/Super_Admin_Command.php
+++ b/src/Super_Admin_Command.php
@@ -23,11 +23,11 @@
 class Super_Admin_Command extends WP_CLI_Command {
 
 	private $fields = array(
-		'user_login'
+		'user_login',
 	);
 
 	public function __construct() {
-		$this->fetcher = new \WP_CLI\Fetchers\User;
+		$this->fetcher = new \WP_CLI\Fetchers\User();
 	}
 
 	/**
@@ -64,11 +64,10 @@ class Super_Admin_Command extends WP_CLI_Command {
 			foreach ( $super_admins as $user_login ) {
 				WP_CLI::line( $user_login );
 			}
-		}
-		else {
+		} else {
 			$output_users = array();
 			foreach ( $super_admins as $user_login ) {
-				$output_user = new stdClass;
+				$output_user = new stdClass();
 
 				$output_user->user_login = $user_login;
 
@@ -95,12 +94,12 @@ class Super_Admin_Command extends WP_CLI_Command {
 	public function add( $args, $_ ) {
 
 		$successes = $errors = 0;
-		$users = $this->fetcher->get_many( $args );
+		$users     = $this->fetcher->get_many( $args );
 		if ( count( $users ) != count( $args ) ) {
 			$errors = count( $args ) - count( $users );
 		}
-		$user_logins = wp_list_pluck( $users, 'user_login' );
-		$super_admins = self::get_admins();
+		$user_logins      = wp_list_pluck( $users, 'user_login' );
+		$super_admins     = self::get_admins();
 		$num_super_admins = count( $super_admins );
 
 		foreach ( $user_logins as $user_login ) {
@@ -121,7 +120,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 				WP_CLI::success( 'Super admins remain unchanged.' );
 			}
 		} else {
-			if ( update_site_option( 'site_admins' , $super_admins ) ) {
+			if ( update_site_option( 'site_admins', $super_admins ) ) {
 				if ( $errors ) {
 					$user_count = count( $args );
 					WP_CLI::error( "Only granted super-admin capabilities to {$successes} of {$user_count} users." );
@@ -154,18 +153,26 @@ class Super_Admin_Command extends WP_CLI_Command {
 			WP_CLI::error( 'No super admins to revoke super-admin privileges from.' );
 		}
 
-		$users = $this->fetcher->get_many( $args );
-		$user_logins = $users ? array_values( array_unique( wp_list_pluck( $users, 'user_login' ) ) ) : array();
+		$users             = $this->fetcher->get_many( $args );
+		$user_logins       = $users ? array_values( array_unique( wp_list_pluck( $users, 'user_login' ) ) ) : array();
 		$user_logins_count = count( $user_logins );
 
 		if ( $user_logins_count < count( $args ) ) {
 			$flipped_user_logins = array_flip( $user_logins );
 			// Fetcher has already warned so don't bother here, but continue with any args that are possible login names to cater for invalid users in the site options meta.
 
-			$user_logins = array_merge( $user_logins, array_unique( array_filter( $args, function ( $v ) use ( $flipped_user_logins ) {
-				// Exclude numeric and email-like logins (login names can be email-like but ignore this given the circumstances).
-				return ! isset( $flipped_user_logins[ $v ] ) && ! is_numeric( $v ) && ! is_email( $v );
-			} ) ) );
+			$user_logins       = array_merge(
+				$user_logins,
+				array_unique(
+					array_filter(
+						$args,
+						function ( $v ) use ( $flipped_user_logins ) {
+							// Exclude numeric and email-like logins (login names can be email-like but ignore this given the circumstances).
+							return ! isset( $flipped_user_logins[ $v ] ) && ! is_numeric( $v ) && ! is_email( $v );
+						}
+					)
+				)
+			);
 			$user_logins_count = count( $user_logins );
 		}
 		if ( ! $user_logins ) {
@@ -174,15 +181,15 @@ class Super_Admin_Command extends WP_CLI_Command {
 
 		$update_super_admins = array_diff( $super_admins, $user_logins );
 		if ( $update_super_admins === $super_admins ) {
-			WP_CLI::error( $user_logins_count  > 1 ? 'None of the given users is a super admin.' : 'The given user is not a super admin.' );
+			WP_CLI::error( $user_logins_count > 1 ? 'None of the given users is a super admin.' : 'The given user is not a super admin.' );
 		}
 
-		update_site_option( 'site_admins' , $update_super_admins );
+		update_site_option( 'site_admins', $update_super_admins );
 
 		$successes = count( $super_admins ) - count( $update_super_admins );
 		if ( $successes === $user_logins_count ) {
 			$message = $user_logins_count > 1 ? 'users' : 'user';
-			$msg = "Revoked super-admin capabilities from {$user_logins_count} {$message}.";
+			$msg     = "Revoked super-admin capabilities from {$user_logins_count} {$message}.";
 		} else {
 			$msg = "Revoked super-admin capabilities from {$successes} of {$user_logins_count} users.";
 		}
@@ -194,6 +201,6 @@ class Super_Admin_Command extends WP_CLI_Command {
 
 	private static function get_admins() {
 		// We don't use get_super_admins() because we don't want to mess with the global
-		return (array) get_site_option( 'site_admins', array('admin') );
+		return (array) get_site_option( 'site_admins', array( 'admin' ) );
 	}
 }

--- a/src/Super_Admin_Command.php
+++ b/src/Super_Admin_Command.php
@@ -93,7 +93,8 @@ class Super_Admin_Command extends WP_CLI_Command {
 	 */
 	public function add( $args, $_ ) {
 
-		$successes = $errors = 0;
+		$successes = 0;
+		$errors    = 0;
 		$users     = $this->fetcher->get_many( $args );
 		if ( count( $users ) !== count( $args ) ) {
 			$errors = count( $args ) - count( $users );

--- a/src/Super_Admin_Command.php
+++ b/src/Super_Admin_Command.php
@@ -1,4 +1,5 @@
 <?php
+use WP_CLI\Fetchers\User as UserFetcher;
 
 /**
  * Lists, adds, or removes super admin users on a multisite installation.
@@ -27,7 +28,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 	);
 
 	public function __construct() {
-		$this->fetcher = new \WP_CLI\Fetchers\User();
+		$this->fetcher = new UserFetcher();
 	}
 
 	/**
@@ -57,7 +58,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 	 *
 	 * @subcommand list
 	 */
-	public function list_( $_, $assoc_args ) {
+	public function list_subcommand( $_, $assoc_args ) {
 		$super_admins = self::get_admins();
 
 		if ( 'list' === $assoc_args['format'] ) {

--- a/src/Super_Admin_Command.php
+++ b/src/Super_Admin_Command.php
@@ -113,7 +113,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 			$successes++;
 		}
 
-		if ( $count( $super_admins ) === $num_super_admins ) {
+		if ( count( $super_admins ) === $num_super_admins ) {
 			if ( $errors ) {
 				$user_count = count( $args );
 				WP_CLI::error( "Couldn't grant super-admin capabilities to {$errors} of {$user_count} users." );

--- a/src/Super_Admin_Command.php
+++ b/src/Super_Admin_Command.php
@@ -57,7 +57,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 	 *
 	 * @subcommand list
 	 */
-	public function _list( $_, $assoc_args ) {
+	public function list_( $_, $assoc_args ) {
 		$super_admins = self::get_admins();
 
 		if ( 'list' === $assoc_args['format'] ) {
@@ -95,7 +95,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 
 		$successes = $errors = 0;
 		$users     = $this->fetcher->get_many( $args );
-		if ( count( $users ) != count( $args ) ) {
+		if ( count( $users ) !== count( $args ) ) {
 			$errors = count( $args ) - count( $users );
 		}
 		$user_logins      = wp_list_pluck( $users, 'user_login' );
@@ -103,7 +103,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 		$num_super_admins = count( $super_admins );
 
 		foreach ( $user_logins as $user_login ) {
-			if ( in_array( $user_login, $super_admins ) ) {
+			if ( in_array( $user_login, $super_admins, true ) ) {
 				WP_CLI::warning( "User '{$user_login}' already has super-admin capabilities." );
 				continue;
 			}
@@ -112,7 +112,7 @@ class Super_Admin_Command extends WP_CLI_Command {
 			$successes++;
 		}
 
-		if ( $num_super_admins === count( $super_admins ) ) {
+		if ( $count( $super_admins ) === $num_super_admins ) {
 			if ( $errors ) {
 				$user_count = count( $args );
 				WP_CLI::error( "Couldn't grant super-admin capabilities to {$errors} of {$user_count} users." );

--- a/super-admin-command.php
+++ b/super-admin-command.php
@@ -4,9 +4,9 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 	return;
 }
 
-$autoload = dirname( __FILE__ ) . '/vendor/autoload.php';
-if ( file_exists( $autoload ) ) {
-	require_once $autoload;
+$wpcli_super_admin_autoloader = dirname( __FILE__ ) . '/vendor/autoload.php';
+if ( file_exists( $wpcli_super_admin_autoloader ) ) {
+	require_once $wpcli_super_admin_autoloader;
 }
 
 WP_CLI::add_command( 'super-admin', 'Super_Admin_Command', array(

--- a/super-admin-command.php
+++ b/super-admin-command.php
@@ -9,10 +9,14 @@ if ( file_exists( $wpcli_super_admin_autoloader ) ) {
 	require_once $wpcli_super_admin_autoloader;
 }
 
-WP_CLI::add_command( 'super-admin', 'Super_Admin_Command', array(
-	'before_invoke' => function () {
-		if ( !is_multisite() ) {
-			WP_CLI::error( 'This is not a multisite installation.' );
-		}
-	}
-) );
+WP_CLI::add_command(
+	'super-admin',
+	'Super_Admin_Command',
+	array(
+		'before_invoke' => function () {
+			if ( ! is_multisite() ) {
+				WP_CLI::error( 'This is not a multisite installation.' );
+			}
+		},
+	)
+);


### PR DESCRIPTION
Add a PHPCS ruleset using the new `WP_CLI_CS` standard.

Fixes #34

Related wp-cli/wp-cli#5179