### PR TITLE
PHP 8.2 Deprecation: Fix creation of dynamic property.

### DIFF
--- a/src/Super_Admin_Command.php
+++ b/src/Super_Admin_Command.php
@@ -28,6 +28,8 @@ class Super_Admin_Command extends WP_CLI_Command {
 		'user_login',
 	];
 
+	private $fetcher;
+
 	public function __construct() {
 		$this->fetcher = new UserFetcher();
 	}


### PR DESCRIPTION
If I use the super-admin command `wp super-admin list` with WP CLI 2.9.0 and PHP 8.2.14, I get the warning:

`PHP Deprecated:  Creation of dynamic property Super_Admin_Command::$fetcher is deprecated in /vendor/wp-cli/super-admin-command/src/Super_Admin_Command.php on line 32`

This PR fixes the warning.