### PR TITLE
Exclude the wp-compat false positives from the PHPStan config

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,3 +11,15 @@ parameters:
   ignoreErrors:
     - identifier: missingType.parameter
     - identifier: missingType.return
+
+    # johnbillion/wp-compat checks every WordPress symbol against the WordPress 4.9
+    # baseline that wp-cli-tests configures, and reports anything newer.
+
+    # WordPress 5.3 only formalized the already documented `...$arg` parameter of
+    # `do_action()` by adding it to the function signature. Additional arguments were
+    # collected through `func_get_args()` before that, so passing the user ID to
+    # `grant_super_admin` and friends has always worked. The identifier already names one
+    # specific parameter of one specific function.
+    -
+      identifier: WPCompat.parameterNotAvailable.doaction.arg
+      path: src/Super_Admin_Command.php


### PR DESCRIPTION
The `johnbillion/wp-compat` PHPStan extension that now ships with `wp-cli-tests` checks every WordPress symbol against the WordPress 4.9 baseline that `wp-cli-tests` configures. It reported four errors here, and all four are the same false positive.

| Count | Reported | Where | Why it is a false positive |
| --- | --- | --- | --- |
| 4 | `Parameter $arg of do_action() is only available since WordPress version 5.3.0` | `src/Super_Admin_Command.php` — `grant_super_admin`, `granted_super_admin`, `revoke_super_admin`, `revoked_super_admin` | WordPress 5.3 only "formalized the existing and already documented `...$arg` parameter by adding it to the function signature". Before that, `do_action()` collected additional arguments through `func_get_args()`, so passing the user ID to these hooks has always worked |

Ignored by error identifier and path. No message scoping was needed: `WPCompat.parameterNotAvailable.doaction.arg` already names one specific parameter of one specific function, so the entry cannot swallow an unrelated diagnostic.

No source changes: nothing here is an actual compatibility problem. Note that the command's existing `before_invoke` check is an `is_multisite()` guard rather than a version check, so it plays no part either way.

## Verification

Run locally against the same dependency versions CI resolves (`johnbillion/wp-compat` 2.0.0, `php-stubs/wordpress-stubs` v6.9.4, `wp-cli/wp-cli-tests` v5.2.3):

- `composer phpstan` — `[OK] No errors`, with no unmatched ignore entries
- As a control, adding a deliberately dead ignore entry does produce an `ignore.unmatched` error, confirming the entry above matches real errors rather than sitting there unused

GitHub Actions was failing to allocate runners across the org while this was written, so CI may need a re-run once that clears.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JSjnuDoRgWkj4DjRgHbtNB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static analysis configuration to ignore a compatibility warning for a variadic action argument.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->